### PR TITLE
Validate requested split strategy

### DIFF
--- a/backend/expense-service/src/main/java/in/techarray/billbuddy/expense_service/strategy/SplitStrategyFactory.java
+++ b/backend/expense-service/src/main/java/in/techarray/billbuddy/expense_service/strategy/SplitStrategyFactory.java
@@ -20,6 +20,10 @@ public class SplitStrategyFactory {
     }
 
     public SplitStrategy getStrategy(SplitType type) {
-        return strategies.get(type);
+        SplitStrategy strategy = strategies.get(type);
+        if (strategy == null) {
+            throw new IllegalArgumentException("Unknown split type: " + type);
+        }
+        return strategy;
     }
 }

--- a/backend/expense-service/src/test/java/in/techarray/billbuddy/expense_service/strategy/SplitStrategyFactoryTest.java
+++ b/backend/expense-service/src/test/java/in/techarray/billbuddy/expense_service/strategy/SplitStrategyFactoryTest.java
@@ -1,7 +1,7 @@
 package in.techarray.billbuddy.expense_service.strategy;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 
@@ -42,7 +42,8 @@ public class SplitStrategyFactoryTest {
     }
 
     @Test
-    void shouldReturnNullForUnknownStrategy() {
-        assertNull(factory.getStrategy(SplitType.SHARE_BASED)); // Assuming SHARE isn't registered
+    void shouldThrowForUnknownStrategy() {
+        assertThrows(IllegalArgumentException.class,
+                () -> factory.getStrategy(SplitType.SHARE_BASED));
     }
 }


### PR DESCRIPTION
## Summary
- prevent null pointer by rejecting unknown split strategy types
- update factory tests for missing split strategies

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689d95e39b708326b92fb7ce170be859