### PR TITLE
Fix percentage split test assertions

### DIFF
--- a/backend/expense-service/src/test/java/in/techarray/billbuddy/expense_service/strategy/PercentageSplitStrategyTest.java
+++ b/backend/expense-service/src/test/java/in/techarray/billbuddy/expense_service/strategy/PercentageSplitStrategyTest.java
@@ -33,17 +33,17 @@ public class PercentageSplitStrategyTest {
 
         assertEquals(2, expenseSplits.size());
 
-        // Check for the split for user2 with 25.0% = 50
+        // Check for the split for user1 with 25.0% = 50.0
         assertTrue(expenseSplits.stream()
                         .anyMatch(split -> split.getUserId().equals(user1) &&
                                            Math.abs(split.getAmountOwed() - 50.0) < 0.001),
-                "Expected split for user1 with amount 40.0 not found.");
+                "Expected split for user1 with amount 50.0 not found.");
 
-        // Check for the split for user2 with 75.0% = 150
+        // Check for the split for user2 with 75.0% = 150.0
         assertTrue(expenseSplits.stream()
                         .anyMatch(split -> split.getUserId().equals(user2) &&
                                            Math.abs(split.getAmountOwed() - 150.0) < 0.001),
-                "Expected split for user2 with amount 80.0 not found.");
+                "Expected split for user2 with amount 150.0 not found.");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- correct user references and expected amounts in PercentageSplitStrategyTest

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689d9a123ae88326b012da6f137aa24c