### PR TITLE
Use lowercase description field in ExpenseRequestDto

### DIFF
--- a/backend/expense-service/src/main/java/in/techarray/billbuddy/expense_service/dto/ExpenseRequestDto.java
+++ b/backend/expense-service/src/main/java/in/techarray/billbuddy/expense_service/dto/ExpenseRequestDto.java
@@ -10,7 +10,7 @@ import lombok.Data;
 
 @Data
 public class ExpenseRequestDto {
-    private String Description;
+    private String description;
     private Double totalAmount;
     private LocalDate date;
     private UUID createdByUserId;


### PR DESCRIPTION
## Summary
- rename `Description` field to `description` in `ExpenseRequestDto`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689d9db5c6d08326b26b81078b413101