### PR TITLE
Clarify password hashing in AuthService

### DIFF
--- a/backend/user-service/src/main/java/in/techarray/billbuddy/user_service/service/AuthService.java
+++ b/backend/user-service/src/main/java/in/techarray/billbuddy/user_service/service/AuthService.java
@@ -52,7 +52,7 @@ public class AuthService {
     public UserDto signUp(String email, String password) {  
         User user = new User();
         user.setEmail(email);
-        user.setPassword(bCryptPasswordEncoder.encode(password)); // In a real application, you should hash the password
+        user.setPassword(bCryptPasswordEncoder.encode(password)); // Hash the password using BCryptPasswordEncoder
         userRepository.save(user);
         return UserDto.from(user); 
     }


### PR DESCRIPTION
## Summary
- Clarify sign-up password hashing comment to mention BCryptPasswordEncoder

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689daa5666f88326a7ba6e47a68bf44f