### PR TITLE
test: cover share split strategy in factory

### DIFF
--- a/backend/expense-service/src/test/java/in/techarray/billbuddy/expense_service/strategy/SplitStrategyFactoryTest.java
+++ b/backend/expense-service/src/test/java/in/techarray/billbuddy/expense_service/strategy/SplitStrategyFactoryTest.java
@@ -13,12 +13,14 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import in.techarray.billbuddy.expense_service.model.SplitType;
+import in.techarray.billbuddy.expense_service.strategy.ShareSplitStrategy;
 
 @ExtendWith(MockitoExtension.class)
 public class SplitStrategyFactoryTest {
     @Mock private EqualSplitStrategy equalSplitStrategy;
     @Mock private ExactSplitStrategy exactSplitStrategy;
     @Mock private PercentageSplitStrategy percentageSplitStrategy;
+    @Mock private ShareSplitStrategy shareSplitStrategy;
 
     private SplitStrategyFactory factory;
 
@@ -28,9 +30,10 @@ public class SplitStrategyFactoryTest {
 
         Mockito.when(exactSplitStrategy.getType()).thenReturn(SplitType.EXACT);
         Mockito.when(percentageSplitStrategy.getType()).thenReturn(SplitType.PERCENTAGE);
+        Mockito.when(shareSplitStrategy.getType()).thenReturn(SplitType.SHARE_BASED);
 
         factory = new SplitStrategyFactory(
-            List.of(equalSplitStrategy, exactSplitStrategy, percentageSplitStrategy)
+            List.of(equalSplitStrategy, exactSplitStrategy, percentageSplitStrategy, shareSplitStrategy)
         );
     }
 
@@ -39,11 +42,16 @@ public class SplitStrategyFactoryTest {
         assertEquals(equalSplitStrategy, factory.getStrategy(SplitType.EQUAL));
         assertEquals(exactSplitStrategy, factory.getStrategy(SplitType.EXACT));
         assertEquals(percentageSplitStrategy, factory.getStrategy(SplitType.PERCENTAGE));
+        assertEquals(shareSplitStrategy, factory.getStrategy(SplitType.SHARE_BASED));
     }
 
     @Test
     void shouldThrowForUnknownStrategy() {
+        SplitStrategyFactory factoryWithoutShare = new SplitStrategyFactory(
+            List.of(equalSplitStrategy, exactSplitStrategy, percentageSplitStrategy)
+        );
+
         assertThrows(IllegalArgumentException.class,
-                () -> factory.getStrategy(SplitType.SHARE_BASED));
+                () -> factoryWithoutShare.getStrategy(SplitType.SHARE_BASED));
     }
 }


### PR DESCRIPTION
## Summary
- mock ShareSplitStrategy in SplitStrategyFactoryTest and verify retrieval
- ensure factory throws for missing share strategy

## Testing
- `mvn -q test` *(fails: Network is unreachable: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.5)*

------
https://chatgpt.com/codex/tasks/task_e_689dae452d948326b6d8e05c31ec90a7